### PR TITLE
Allow for scheme-less strings

### DIFF
--- a/app/runtimevar/flags.go
+++ b/app/runtimevar/flags.go
@@ -1,0 +1,15 @@
+package runtimevar
+
+import (
+	"flag"
+
+	"github.com/sfomuseum/go-flags/flagset"
+)
+
+var timeout int
+
+func DefaultFlagSet() *flag.FlagSet {
+	fs := flagset.NewFlagSet("publish")
+	fs.IntVar(&timeout, "timeout", 0, "The maximum number of second in which a variable can be resolved. If 0 no timeout is applied.")
+	return fs
+}

--- a/app/runtimevar/options.go
+++ b/app/runtimevar/options.go
@@ -1,0 +1,34 @@
+package runtimevar
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/sfomuseum/go-flags/flagset"
+)
+
+type RunOptions struct {
+	Timeout int
+	Vars    []string
+}
+
+func OptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, error) {
+
+	flagset.Parse(fs)
+
+	err := flagset.SetFlagsFromEnvVars(fs, "RUNTIMEVAR")
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to derive flags from environment variables, %w", err)
+	}
+
+	vars := fs.Args()
+
+	opts := &RunOptions{
+		Timeout: timeout,
+		Vars:    vars,
+	}
+
+	return opts, nil
+}

--- a/app/runtimevar/runtimetvar.go
+++ b/app/runtimevar/runtimetvar.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/sfomuseum/runtimevar"
+	_ "gocloud.dev/runtimevar/awsparamstore"
+	_ "gocloud.dev/runtimevar/constantvar"
+	_ "gocloud.dev/runtimevar/filevar"
+)
+
+func main() {
+
+	timeout := flag.Int("timeout", 0, "The maximum number of second in which a variable can be resolved. If 0 no timeout is applied.")
+
+	flag.Parse()
+
+	ctx := context.Background()
+
+	if *timeout > 0 {
+
+		c, cancel := context.WithTimeout(ctx, time.Duration(*timeout)*time.Second)
+		defer cancel()
+
+		ctx = c
+	}
+
+	for _, uri := range flag.Args() {
+
+		str_var, err := runtimevar.StringVar(ctx, uri)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf(str_var)
+	}
+}

--- a/cmd/runtimevar/main.go
+++ b/cmd/runtimevar/main.go
@@ -2,41 +2,21 @@ package main
 
 import (
 	"context"
-	"flag"
-	"fmt"
-	"log"
-	"time"
+	"log/slog"
+	"os"
 
-	"github.com/sfomuseum/runtimevar"
-	_ "gocloud.dev/runtimevar/awsparamstore"
-	_ "gocloud.dev/runtimevar/constantvar"
-	_ "gocloud.dev/runtimevar/filevar"
+	"github.com/sfomuseum/runtimevar/app/runtimevar"
 )
 
 func main() {
 
-	timeout := flag.Int("timeout", 0, "The maximum number of second in which a variable can be resolved. If 0 no timeout is applied.")
-
-	flag.Parse()
-
 	ctx := context.Background()
+	logger := slog.Default()
 
-	if *timeout > 0 {
+	err := runtimevar.Run(ctx, logger)
 
-		c, cancel := context.WithTimeout(ctx, time.Duration(*timeout)*time.Second)
-		defer cancel()
-
-		ctx = c
-	}
-
-	for _, uri := range flag.Args() {
-
-		str_var, err := runtimevar.StringVar(ctx, uri)
-
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		fmt.Printf(str_var)
+	if err != nil {
+		logger.Error("Failed to run application", "error", err)
+		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/aaronland/go-aws-auth v1.3.1
+	github.com/sfomuseum/go-flags v0.10.0
 	gocloud.dev v0.36.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/sfomuseum/go-flags v0.10.0 h1:1OC1ACxpWMsl3XQ9OeNVMQj7Zi2CzufP3Rym3mPI8HU=
+github.com/sfomuseum/go-flags v0.10.0/go.mod h1:VXOnnX1/yxQpX2yiwHaBV6aCmhtszQOL5bL1/nNo3co=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/string.go
+++ b/string.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/aaronland/go-aws-auth"	
+	"github.com/aaronland/go-aws-auth"
 	gc "gocloud.dev/runtimevar"
 	"gocloud.dev/runtimevar/awsparamstore"
 	_ "gocloud.dev/runtimevar/constantvar"
 	_ "gocloud.dev/runtimevar/filevar"
-	_ "log"	
 )
 
 // StringVar returns the latest string value contained by 'uri', which is expected
@@ -26,7 +25,7 @@ func StringVar(ctx context.Context, uri string) (string, error) {
 	if u.Scheme == "" {
 		return u.Path, nil
 	}
-	
+
 	q := u.Query()
 
 	if q.Get("decoder") == "" {
@@ -54,7 +53,7 @@ func StringVar(ctx context.Context, uri string) (string, error) {
 				return "", fmt.Errorf("Failed to create AWS session credentials, %w", err)
 			}
 
-			v, v_err = awsparamstore.OpenVariableV2(aws_auth, u.Host, gc.StringDecoder, nil)			
+			v, v_err = awsparamstore.OpenVariableV2(aws_auth, u.Host, gc.StringDecoder, nil)
 		}
 
 	default:
@@ -69,7 +68,7 @@ func StringVar(ctx context.Context, uri string) (string, error) {
 	}
 
 	if v_err != nil {
-		return "", v_err
+		return "", fmt.Errorf("Failed to open variable, %w", v_err)
 	}
 
 	defer v.Close()
@@ -77,7 +76,7 @@ func StringVar(ctx context.Context, uri string) (string, error) {
 	snapshot, err := v.Latest(ctx)
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Failed to derive latest snapshot for variable, %w", err)
 	}
 
 	return snapshot.Value.(string), nil

--- a/string.go
+++ b/string.go
@@ -3,13 +3,14 @@ package runtimevar
 import (
 	"context"
 	"fmt"
+	"net/url"
+
 	"github.com/aaronland/go-aws-auth"	
 	gc "gocloud.dev/runtimevar"
 	"gocloud.dev/runtimevar/awsparamstore"
 	_ "gocloud.dev/runtimevar/constantvar"
 	_ "gocloud.dev/runtimevar/filevar"
-	_ "log"
-	"net/url"
+	_ "log"	
 )
 
 // StringVar returns the latest string value contained by 'uri', which is expected
@@ -19,9 +20,13 @@ func StringVar(ctx context.Context, uri string) (string, error) {
 	u, err := url.Parse(uri)
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Failed to parse URI, %w", err)
 	}
 
+	if u.Scheme == "" {
+		return u.Path, nil
+	}
+	
 	q := u.Query()
 
 	if q.Get("decoder") == "" {

--- a/string_test.go
+++ b/string_test.go
@@ -15,6 +15,8 @@ func TestConstantVar(t *testing.T) {
 
 	tests := map[string]string{
 		"constant://?val=hello+world": "hello world",
+		"/foo/bar/baz":                "/foo/bar/baz",
+		"test":                        "test",
 	}
 
 	for uri, expected := range tests {

--- a/vendor/github.com/sfomuseum/go-flags/LICENSE
+++ b/vendor/github.com/sfomuseum/go-flags/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2020, City and County of San Francisco, acting by and through its
+Airport Commission ("City"). All rights reserved.
+
+The City and County of San Francisco, acting by and through its Airport
+Commission, created and operates the SFO Museum.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+3.  Neither the name of the City nor the names of its contributors may be used
+    to endorse or promote products derived from this software without specific
+    prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/sfomuseum/go-flags/flagset/flagset.go
+++ b/vendor/github.com/sfomuseum/go-flags/flagset/flagset.go
@@ -1,0 +1,85 @@
+// package flagset provides methods for working with `flag.FlagSet` instances.
+package flagset
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+// Parse command line arguments with a flag.FlagSet instance.
+func Parse(fs *flag.FlagSet) {
+
+	args := os.Args[1:]
+
+	if len(args) > 0 && args[0] == "-h" {
+		fs.Usage()
+		os.Exit(0)
+	}
+
+	fs.Parse(args)
+}
+
+// Assign values to a flag.FlagSet instance from matching environment variables.
+func SetFlagsFromEnvVars(fs *flag.FlagSet, prefix string) error {
+	return SetFlagsFromEnvVarsWithFeedback(fs, prefix, false)
+}
+
+// Assign values to a flag.FlagSet instance from matching environment variables, optionally logging progress and other feedback.
+func SetFlagsFromEnvVarsWithFeedback(fs *flag.FlagSet, prefix string, feedback bool) error {
+
+	fs.VisitAll(func(fl *flag.Flag) {
+
+		name := fl.Name
+		env := FlagNameToEnvVar(prefix, name)
+
+		val, ok := os.LookupEnv(env)
+
+		if ok {
+
+			if feedback {
+				log.Printf("set -%s flag from %s environment variable\n", name, env)
+			}
+
+			fs.Set(name, val)
+		}
+	})
+
+	return nil
+}
+
+// Create a new flag.FlagSet instance.
+func NewFlagSet(name string) *flag.FlagSet {
+
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
+
+	fs.Usage = func() {
+		fs.PrintDefaults()
+	}
+
+	return fs
+}
+
+// FlagNameToEnvVar formats 'name' and 'prefix' in to an environment variable name, used to lookup
+// a value.
+func FlagNameToEnvVar(prefix string, name string) string {
+
+	prefix = normalizeEnvVar(prefix)
+	name = normalizeEnvVar(name)
+
+	return fmt.Sprintf("%s_%s", prefix, name)
+
+}
+
+// normalizeEnvVar normalizes a flag name in to its corresponding environment variable name.
+func normalizeEnvVar(raw string) string {
+
+	new := raw
+
+	new = strings.ToUpper(new)
+	new = strings.Replace(new, "-", "_", -1)
+
+	return new
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -185,6 +185,9 @@ github.com/googleapis/gax-go/v2/internal
 # github.com/jmespath/go-jmespath v0.4.0
 ## explicit; go 1.14
 github.com/jmespath/go-jmespath
+# github.com/sfomuseum/go-flags v0.10.0
+## explicit; go 1.16
+github.com/sfomuseum/go-flags/flagset
 # go.opencensus.io v0.24.0
 ## explicit; go 1.13
 go.opencensus.io


### PR DESCRIPTION
* Allow for scheme-less strings (don't interpolate them)
* Move the guts of `cmd/runtimevar` in to `app/runtimevar`